### PR TITLE
Add a helper script for git diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !lib-common/uclibc/lib/*
 !kernel/src/memory/mm_malloc.o
 !testcase/user.ld
+!/git-*

--- a/git-diff
+++ b/git-diff
@@ -1,2 +1,2 @@
 #!/bin/bash
-git log --author=15 --format=%H -n 1 | xargs git diff
+git log --author=15 --format=%H -n 1 | xargs git diff $@

--- a/git-diff
+++ b/git-diff
@@ -1,0 +1,2 @@
+#!/bin/bash
+git log --author=15 --format=%H -n 1 | xargs git diff


### PR DESCRIPTION
I love to use `git diff` to review my changes before committing. However this tracer bot is killing this feature for me. So I added a helper script.

Usage:

```
$ ./git-diff
```

HACK: I assumed everyone's SID has `15` in it.
