### PR TITLE
Modify 'run' target with pattern matching, one can use command like '…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,12 @@ clean: clean-cpp
 
 ##### some convinient rules #####
 
-USERPROG := obj/testcase/mov
-ENTRY := $(USERPROG)
+USERPROG := obj/testcase
 
-entry: $(ENTRY)
-	objcopy -S -O binary $(ENTRY) entry
-
-run: $(nemu_BIN) $(USERPROG) entry
+run-%: $(nemu_BIN) $(USERPROG)/%
 	$(call git_commit, "run")
-	$(nemu_BIN) $(USERPROG)
+	objcopy -S -O binary $(USERPROG)/$* entry
+	$(nemu_BIN) $(USERPROG)/$*
 
 gdb: $(nemu_BIN) $(USERPROG) entry
 	$(call git_commit, "gdb")


### PR DESCRIPTION
…make run-mov', 'make run-add' to run different test cases without modifying USERPROG variable in Makefile manually.

```shell
$ make run-mov
+ as testcase/src/mov.S
+ ld obj/testcase/mov
objcopy -S -O binary obj/testcase/mov entry
obj/nemu/nemu obj/testcase/mov
Welcome to NEMU!
The executable is obj/testcase/mov.
For help, type "help"
(nemu) 

$ make run-add
+ as testcase/src/start.S
+ cc testcase/src/add.c
+ ld obj/testcase/add
objcopy -S -O binary obj/testcase/add entry
obj/nemu/nemu obj/testcase/add
Welcome to NEMU!
The executable is obj/testcase/add.
For help, type "help"
(nemu) 

```